### PR TITLE
Update to Debian 10 and also save some space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM debian:9-slim
+FROM debian:10-slim
 
 RUN apt-get update \
     && apt-get -y install socat \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Hi, Debian 10 is out, let's use it ;)

Also I added an extra step to remove the index files, which is also considered as a best practice:
https://docs.docker.com/v17.09/engine/userguide/eng-image/dockerfile_best-practices/#apt-get

I removed the apt-clean step because of this note:
Note: The official Debian and Ubuntu images automatically run apt-get clean, so explicit invocation is not required.