### PR TITLE
Add ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:9-slim
 
 RUN apt-get update \
-    && apt-get -y install socat \
+    && apt-get -y install socat ca-certificates \
     && apt-get clean
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Hi, ca-certificates can be useful to add if you inject some process which requires TLS.